### PR TITLE
Fix print issue, add CI action

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   run-ci:
+    runs-on: [ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -2,7 +2,6 @@ name: "CI Checks"
 on:
   workflow_dispatch:
   push:
-  pull_request:
 
 jobs:
   run-ci:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,0 +1,17 @@
+name: "CI Checks"
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  run-ci:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build CLI
+        run: |
+          make build
+      - name: Run tests
+        run: |
+          make test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "mode": "auto",
             "program": "./main.go",
             "cwd": ".",
-            "args": ["print", "-d", "test/contexts/standards"]
+            "args": ["print", "-d", "test/contexts/standard"]
         }
     ]
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -5,4 +5,5 @@ import "github.com/maxnorth/nv/internal/providers"
 type Resolver struct {
 	providers       map[string]providers.Provider
 	loadedProviders map[providers.Provider]struct{}
+	LoadedVars      []string
 }

--- a/test/contexts/standard/.env
+++ b/test/contexts/standard/.env
@@ -1,1 +1,2 @@
 EXAMPLE_VALUE=nv://echo/something/or/other
+STATIC_VALUE=this did not use a resolver

--- a/test/e2e/print.yml
+++ b/test/e2e/print.yml
@@ -5,20 +5,24 @@ test:
       cmd: nv print
       out: |
         EXAMPLE_VALUE=something/or/other
+        STATIC_VALUE=this did not use a resolver
   - it: can print in yaml
     with:
       cmd: nv print -o yaml
       out: |
         EXAMPLE_VALUE: "something/or/other"
+        STATIC_VALUE: "this did not use a resolver"
   - it: can print in json
     with:
       cmd: nv print -o json
       out: |
         {
-          "EXAMPLE_VALUE": "something/or/other"
+          "EXAMPLE_VALUE": "something/or/other",
+          "STATIC_VALUE": "this did not use a resolver"
         }
   - it: can print for shell eval
     with:
       cmd: nv print -o shell
       out: |
         export EXAMPLE_VALUE="something/or/other"
+        export STATIC_VALUE="this did not use a resolver"

--- a/test/e2e/print.yml
+++ b/test/e2e/print.yml
@@ -25,4 +25,4 @@ test:
       cmd: nv print -o shell
       out: |
         export EXAMPLE_VALUE="something/or/other"
-        export STATIC_VALUE="this did not use a resolver"
+        export STATIC_VALUE="this did not use a resolverd"

--- a/test/e2e/print.yml
+++ b/test/e2e/print.yml
@@ -25,4 +25,4 @@ test:
       cmd: nv print -o shell
       out: |
         export EXAMPLE_VALUE="something/or/other"
-        export STATIC_VALUE="this did not use a resolverd"
+        export STATIC_VALUE="this did not use a resolver"


### PR DESCRIPTION
This does two things:
- Makes `nv print` output include all env vars modified by nv, including all loaded from .env files, not just the ones it resolved
- Adds a GH action to run CI checks - build & test