### PR TITLE
Optional nv yaml

### DIFF
--- a/internal/resolver/load.go
+++ b/internal/resolver/load.go
@@ -23,13 +23,17 @@ func Load(env string) (*Resolver, error) {
 	r := &Resolver{
 		providers:       map[string]providers.Provider{},
 		loadedProviders: map[providers.Provider]struct{}{},
+		configFound:     false,
 		LoadedVars:      keys,
 	}
 
 	yamlBytes, err := os.ReadFile("./nv.yaml")
 	if _, isPathErr := err.(*fs.PathError); err != nil && !isPathErr {
 		return nil, fmt.Errorf("failed to load nv.yaml: %s", err)
+	} else if err != nil {
+		r.configFound = false
 	}
+
 	jsonBytes, err := yamlToJson(yamlBytes)
 	if err != nil {
 		return nil, err

--- a/internal/resolver/load.go
+++ b/internal/resolver/load.go
@@ -23,7 +23,7 @@ func Load(env string) (*Resolver, error) {
 	r := &Resolver{
 		providers:       map[string]providers.Provider{},
 		loadedProviders: map[providers.Provider]struct{}{},
-		configFound:     false,
+		configFound:     true,
 		LoadedVars:      keys,
 	}
 

--- a/internal/resolver/resolve.go
+++ b/internal/resolver/resolve.go
@@ -46,15 +46,16 @@ func (r *Resolver) ResolveUrl(rawUrl string) (string, error) {
 
 	resolver, found := r.providers[resolverName]
 	if !found {
-		// TODO: revisit - happy with this pattern?
-		fmt.Printf("warning: no resolver found for '%s'\n", resolverName)
-		return "", nil
+		if !r.configFound {
+			fmt.Fprintf(os.Stderr, "warning: no nv.yaml was found, use this to define custom resolvers\n")
+		}
+		return "", fmt.Errorf("no resolver found for '%s'", resolverName)
 	}
 
 	if _, loaded := r.loadedProviders[resolver]; !loaded {
 		err := resolver.Load()
 		if err != nil {
-			return "", fmt.Errorf("failed to load provider '%s': %s\n", resolverName, err)
+			return "", fmt.Errorf("failed to load provider '%s': %s", resolverName, err)
 		}
 
 		r.loadedProviders[resolver] = struct{}{}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -5,5 +5,6 @@ import "github.com/maxnorth/nv/internal/providers"
 type Resolver struct {
 	providers       map[string]providers.Provider
 	loadedProviders map[providers.Provider]struct{}
+	configFound     bool
 	LoadedVars      []string
 }

--- a/test/contexts/malformed/nv.yaml
+++ b/test/contexts/malformed/nv.yaml
@@ -1,0 +1,1 @@
+"malformed yaml

--- a/test/e2e/behavior-resolver.yml
+++ b/test/e2e/behavior-resolver.yml
@@ -6,6 +6,15 @@ test:
       files:
         .env: |
           EXAMPLE_VALUE=nv+fake://this/will/fail
+        nv.yaml: ""
+      err: |
+        Error: no resolver found for 'fake'
+  - it: prints error when resolver type is missing, plus warning for missing nv.yaml
+    with:
+      cmd: nv print
+      files:
+        .env: |
+          EXAMPLE_VALUE=nv+fake://this/will/fail
       err: |
         warning: no nv.yaml was found, use this to define custom resolvers
         Error: no resolver found for 'fake'

--- a/test/e2e/behavior-resolver.yml
+++ b/test/e2e/behavior-resolver.yml
@@ -1,0 +1,11 @@
+describe: behavior of resolver
+test:
+  - it: prints error when resolver type is missing
+    with:
+      cmd: nv print
+      files:
+        .env: |
+          EXAMPLE_VALUE=nv+fake://this/will/fail
+      err: |
+        warning: no nv.yaml was found, use this to define custom resolvers
+        Error: no resolver found for 'fake'

--- a/test/e2e/config-nv.yml
+++ b/test/e2e/config-nv.yml
@@ -1,7 +1,13 @@
 describe: nv.yaml config
 test:
-  - it: causes fatal error when nv.yaml is missing
+  - it: does not cause error when nv.yaml is missing
     with:
       cmd: nv print
+  - it: causes error when nv.yaml is malformed
+    with:
+      cmd: nv print
+      files:
+        nv.yaml: |
+          "unclosed string
       err: |
-        Error: nv.yaml not found
+        Error: failed to parse nv.yaml: yaml: line 2: found unexpected end of stream

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -83,7 +83,7 @@ func runTestCase(t *testing.T, testSubject *TestSubject, testCase *TestCase) {
 	exitCode, outstr, errstr := runCommand(t, testCase.With.Cmd, testCase.With.Dir)
 
 	if exitCode != testCase.With.Exit {
-		t.Fatalf("error: actual exit code '%d' does not match expect '%d'", exitCode, testCase.With.Exit)
+		t.Fatalf("error: actual exit code '%d' does not match expected '%d'", exitCode, testCase.With.Exit)
 	}
 
 	if errstr != testCase.With.Err {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -25,3 +25,7 @@ func Test_E2E_Print(t *testing.T) {
 func Test_E2E_Run(t *testing.T) {
 	e2e.RunTestFile(t, "cmd-run.yml")
 }
+
+func Test_E2E_Resolver(t *testing.T) {
+	e2e.RunTestFile(t, "behavior-resolver.yml")
+}

--- a/test/util.go
+++ b/test/util.go
@@ -20,10 +20,10 @@ func RootDir() string {
 	return rootDir
 }
 
-func GetColoredDiff(a, b string) string {
+func GetColoredDiff(current, expected string) string {
 	dmp := diffmatchpatch.New()
 
-	diffs := dmp.DiffMain(a, b, true)
+	diffs := dmp.DiffMain(expected, current, true)
 
 	colors := map[diffmatchpatch.Operation]string{
 		diffmatchpatch.DiffInsert: "\x1b[42m",

--- a/test/util.go
+++ b/test/util.go
@@ -23,7 +23,8 @@ func RootDir() string {
 func GetColoredDiff(current, expected string) string {
 	dmp := diffmatchpatch.New()
 
-	diffs := dmp.DiffMain(expected, current, true)
+	diffs := dmp.DiffMain(expected, current, false)
+	diffs = dmp.DiffCleanupSemantic(diffs)
 
 	colors := map[diffmatchpatch.Operation]string{
 		diffmatchpatch.DiffInsert: "\x1b[42m",


### PR DESCRIPTION
Makes the nv.yaml file optional. Couple reasons for this:
- Makes nv usable as a simple .env loader without secrets
- Anticipates that built-in resolvers will be added, users may not have a need for custom config