### PR TITLE
Fix bug changing run pwd when using --dir

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,17 +16,19 @@ func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use: "nv",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			dir := cmd.Flag("dir").Value.String()
 			workDir, _ := os.Getwd()
-			dirPath := filepath.Join(workDir, dir)
-			if strings.HasPrefix(dir, "/") {
-				dirPath = dir
-			}
-			if err := os.Chdir(dirPath); err != nil {
-				// TODO: other kinds of errors? permission issues?
-				return fmt.Errorf("target directory not found: %s", dirPath)
-			}
 			initWorkDir = workDir
+
+			dir := cmd.Flag("dir").Value.String()
+			if !strings.HasPrefix(dir, "/") {
+				dir = filepath.Join(workDir, dir)
+			}
+
+			if err := os.Chdir(dir); err != nil {
+				// TODO: other kinds of errors? permission issues?
+				return fmt.Errorf("target directory not found: %s", dir)
+			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,10 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+var initWorkDir string
 
 func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
@@ -15,11 +18,15 @@ func NewRootCmd() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			dir := cmd.Flag("dir").Value.String()
 			workDir, _ := os.Getwd()
-			dirPath := path.Join(workDir, dir)
+			dirPath := filepath.Join(workDir, dir)
+			if strings.HasPrefix(dir, "/") {
+				dirPath = dir
+			}
 			if err := os.Chdir(dirPath); err != nil {
 				// TODO: other kinds of errors? permission issues?
 				return fmt.Errorf("target directory not found: %s", dirPath)
 			}
+			initWorkDir = workDir
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,6 +55,7 @@ func execCommand(cobraCmd *cobra.Command, commandArgs []string) error {
 		args = commandArgs[1:]
 	}
 	cmd := exec.Command(command, args...)
+	cmd.Dir = initWorkDir
 	cmd.Stdin = cobraCmd.InOrStdin()
 	cmd.Stdout = cobraCmd.OutOrStdout()
 	cmd.Stderr = cobraCmd.ErrOrStderr()

--- a/test/e2e/cmd-run.yml
+++ b/test/e2e/cmd-run.yml
@@ -34,3 +34,9 @@ test:
       files: *defaultFiles
       out: |
         something
+  - it: runs command in current dir even when --dir arg provided
+    with:
+      cmd: nv --dir /bin -- pwd
+      pwd: /var
+      out: |
+        /var


### PR DESCRIPTION
Fixes a bug related to working dir of `run` command when using `--dir` flag. The specified `--dir` is only intended to configure where to load `.env` and `nv.yaml` files from, the working dir of the command being run should not change from the user's current dir.